### PR TITLE
Added WhereClause parameter to Table Filter script

### DIFF
--- a/add-table-filter.ps1
+++ b/add-table-filter.ps1
@@ -99,7 +99,8 @@
 
   [Parameter(Mandatory=$True,Position=2)]
   [string] $TableName,
-
+  [Parameter(Mandatory=$True)]
+  [string] $WhereClause,
   [string] $Excludes,
 
   [Parameter(Mandatory=$True)]
@@ -115,8 +116,6 @@
   [string] $SecondaryPassword = $PrimaryPassword
 )
 
-
-$whereClause = "'{{{ZUMERO_USER_NAME}}}' = name"
 
 $ErrorActionPreference = "Stop"
 
@@ -176,7 +175,7 @@ Function FilterTable($dbfile_name, $table_name)
       $ft = $db.GetFilteredTable($table);
     }
 
-    $ft.SetWhereClause($whereClause);
+    $ft.SetWhereClause($WhereClause);
 
     $hasUser = $false
 

--- a/add-table-filter.ps1
+++ b/add-table-filter.ps1
@@ -99,7 +99,6 @@
 
   [Parameter(Mandatory=$True,Position=2)]
   [string] $TableName,
-  [Parameter(Mandatory=$True)]
   [string] $WhereClause,
   [string] $Excludes,
 
@@ -122,6 +121,12 @@ $ErrorActionPreference = "Stop"
 if ([Environment]::Is64BitProcess)
 {
     "This script must be run from a 32-bit Powershell environment."
+    Exit
+}
+
+if ([string]::IsNullOrEmpty($WhereClause) -Or [string]::IsNullOrEmpty($Excludes))
+{
+     "This script must provide at least a Where clause or Excludes text"
     Exit
 }
 

--- a/add-table-filter.ps1
+++ b/add-table-filter.ps1
@@ -124,7 +124,7 @@ if ([Environment]::Is64BitProcess)
     Exit
 }
 
-if ([string]::IsNullOrEmpty($WhereClause) -Or [string]::IsNullOrEmpty($Excludes))
+if ([string]::IsNullOrEmpty($WhereClause) -And [string]::IsNullOrEmpty($Excludes))
 {
      "This script must provide at least a Where clause or Excludes text"
     Exit


### PR DESCRIPTION
Adding whereClause a a parameter rather than a hardcoded value in the script means you can re-use the same script to apply any filter you like rather than different scripts for different filters
